### PR TITLE
macOS (Catalina+) – Fix build/link on modern SDKs and Apple Silicon

### DIFF
--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -349,6 +349,8 @@ elseif(MACOSX)
   find_library(MAC_FRAME_IOKIT IOKit ${CMAKE_SYSTEM_FRAMEWORK_PATH} REQUIRED)
   find_library(MAC_FRAME_OPENGL OpenGL ${CMAKE_SYSTEM_FRAMEWORK_PATH} REQUIRED)
   find_library(MAC_FRAME_SYSTEM System ${CMAKE_SYSTEM_FRAMEWORK_PATH} REQUIRED)
+  find_library(MAC_FRAME_HITOOLBOX HIToolbox ${CMAKE_SYSTEM_FRAMEWORK_PATH})
+  find_library(MAC_FRAME_CARBON Carbon ${CMAKE_SYSTEM_FRAMEWORK_PATH} REQUIRED)
 
   mark_as_advanced(MAC_FRAME_ACCELERATE
                    MAC_FRAME_APPKIT
@@ -361,7 +363,9 @@ elseif(MACOSX)
                    MAC_FRAME_FOUNDATION
                    MAC_FRAME_IOKIT
                    MAC_FRAME_OPENGL
-                   MAC_FRAME_SYSTEM)
+                   MAC_FRAME_SYSTEM
+                   MAC_FRAME_HITOOLBOX
+                   MAC_FRAME_CARBON)
 elseif(LINUX)
   if(WITH_GTK3)
     find_package("GTK3" 2.0)

--- a/extern/CMakeProject-png.cmake
+++ b/extern/CMakeProject-png.cmake
@@ -51,4 +51,8 @@ else()
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libpng>
     $<INSTALL_INTERFACE:libpng>
   )
+  # On Apple Silicon/macOS, avoid unresolved ARM NEON hooks in libpng by disabling NEON opts
+  if(APPLE)
+    target_compile_definitions("png" PRIVATE PNG_ARM_NEON_OPT=0)
+  endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -258,7 +258,7 @@ elseif(APPLE)
       "${SM_XCODE_DIR}/Libraries")
       # XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
       # "${SM_XCODE_DIR}/StepMania.entitlements")
-      
+
   set(APPLE_BUNDLE_RESOURCES
     "${SM_ROOT_DIR}/Announcers"
     "${SM_ROOT_DIR}/BackgroundEffects"
@@ -272,7 +272,7 @@ elseif(APPLE)
     "${SM_ROOT_DIR}/Songs"
     "${SM_ROOT_DIR}/Themes"
   )
-  
+
   target_sources("${SM_EXE_NAME}" PUBLIC ${APPLE_BUNDLE_RESOURCES})
   set_source_files_properties(${APPLE_BUNDLE_RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
@@ -544,6 +544,7 @@ elseif(APPLE)
               ${MAC_FRAME_IOKIT}
               ${MAC_FRAME_OPENGL}
               ${MAC_FRAME_COREFOUNDATION}
+              ${MAC_FRAME_CARBON}
               ${MAC_FRAME_AUDIOTOOLBOX}
               ${MAC_FRAME_AUDIOUNIT}
               ${MAC_FRAME_COREAUDIO}
@@ -552,6 +553,10 @@ elseif(APPLE)
   list(APPEND SMDATA_LINK_LIB
               "${BZIP2_LIBRARY_RELEASE}"
               "${ICONV_LIBRARIES}")
+
+  if(MAC_FRAME_HITOOLBOX)
+    list(APPEND SMDATA_LINK_LIB ${MAC_FRAME_HITOOLBOX})
+  endif()
 
   if(HAS_FFMPEG)
     list(APPEND SMDATA_LINK_LIB
@@ -633,7 +638,7 @@ else() # Unix / Linux TODO: Remember to find and locate the zip archive files.
   if(PCRE_FOUND)
     list(APPEND SMDATA_LINK_LIB ${PCRE_LIBRARY})
   endif()
-  
+
   if(LIBXTST_FOUND)
     list(APPEND SMDATA_LINK_LIB ${LIBXTST_LIBRARY})
   endif()

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
@@ -8,6 +8,7 @@
 #include <IOKit/storage/IOMedia.h>
 #include <IOKit/usb/USBSpec.h>
 #include <IOKit/usb/IOUSBLib.h>
+#include <CoreFoundation/CoreFoundation.h>
 #if defined(HAVE_SYS_PARAM_H)
 #include <sys/param.h>
 #endif
@@ -48,13 +49,13 @@ MemoryCardDriverThreaded_MacOSX::~MemoryCardDriverThreaded_MacOSX()
 void MemoryCardDriverThreaded_MacOSX::Unmount( UsbStorageDevice *pDevice )
 {
 #if defined(SYNC_VOLUME_FULLSYNC) && defined(SYNC_VOLUME_WAIT)
-	
+
 	if( sync_volume_np( pDevice->sOsMountDir.c_str(), SYNC_VOLUME_FULLSYNC | SYNC_VOLUME_WAIT ) != 0 )
 		LOG->Warn( "Failed to flush the memory card." );
 #else
 	// Carbon PBFlushVolSync is unavailable on 64-bit; skip explicit flush
 	LOG->Warn( "PBFlushVolSync unavailable; skipping volume flush." );
-	
+
 #endif
 }
 
@@ -67,7 +68,7 @@ bool MemoryCardDriverThreaded_MacOSX::USBStorageDevicesChanged()
 static int GetIntProperty( io_registry_entry_t entry, CFStringRef key )
 {
 	CFTypeRef t = IORegistryEntryCreateCFProperty( entry, key, nullptr, 0 );
-	
+
 	if( !t )
 		return -1;
 	if( CFGetTypeID( t ) != CFNumberGetTypeID() )
@@ -76,7 +77,7 @@ static int GetIntProperty( io_registry_entry_t entry, CFStringRef key )
 		return -1;
 	}
 	int num;
-	
+
 	if( !CFNumberGetValue(CFNumberRef(t), kCFNumberIntType, &num) )
 		num = -1;
 	CFRelease( t );
@@ -86,7 +87,7 @@ static int GetIntProperty( io_registry_entry_t entry, CFStringRef key )
 static RString GetStringProperty( io_registry_entry_t entry, CFStringRef key )
 {
 	CFTypeRef t = IORegistryEntryCreateCFProperty( entry, key, nullptr, 0 );
-	
+
 	if( !t )
 		return RString();
 	if( CFGetTypeID( t ) != CFStringGetTypeID() )
@@ -94,12 +95,12 @@ static RString GetStringProperty( io_registry_entry_t entry, CFStringRef key )
 		CFRelease( t );
 		return RString();
 	}
-	
+
 	CFStringRef s = CFStringRef( t );
 	RString ret;
 	const size_t len = CFStringGetMaximumSizeForEncoding( CFStringGetLength(s), kCFStringEncodingUTF8 );
 	char *buf = new char[len + 1];
-		
+
 	if( CFStringGetCString( s, buf, len + 1, kCFStringEncodingUTF8 ) )
 		ret = buf;
 	delete[] buf;
@@ -113,42 +114,42 @@ void MemoryCardDriverThreaded_MacOSX::GetUSBStorageDevices( vector<UsbStorageDev
 	// First, get all device paths
 	struct statfs *fs;
 	int num = getfsstat( nullptr, 0, MNT_NOWAIT );
-	
+
 	fs = new struct statfs[num];
-	
+
 	num = getfsstat( fs, num * sizeof(struct statfs), MNT_NOWAIT );
 	ASSERT( num != -1 );
-	
+
 	for( int i = 0; i < num; ++i )
 	{
 		if( strncmp(fs[i].f_mntfromname, _PATH_DEV, strlen(_PATH_DEV)) )
 			continue;
-		
+
 		const RString& sDevicePath = fs[i].f_mntfromname;
 		const RString& sDisk = Basename( sDevicePath ); // disk#[[s#] ...]
-		
+
 		// Now that we have the disk name, look up the IOServices associated with it.
 		CFMutableDictionaryRef dict;
-		
+
 		if( !(dict = IOBSDNameMatching(kIOMasterPortDefault, 0, sDisk)) )
 			continue;
-		
+
 		// Look for certain properties: Leaf, Ejectable, Writable.
 		CFDictionarySetValue( dict, CFSTR(kIOMediaLeafKey), kCFBooleanTrue );
 		CFDictionarySetValue( dict, CFSTR(kIOMediaEjectableKey), kCFBooleanTrue );
 		CFDictionarySetValue( dict, CFSTR(kIOMediaWritableKey), kCFBooleanTrue );
-		
+
 		// Get the matching iterator. As always, this consumes a reference to dict.
 		io_iterator_t iter;
 		kern_return_t ret = IOServiceGetMatchingServices( kIOMasterPortDefault, dict, &iter );
-		
+
 		if( ret != KERN_SUCCESS || iter == 0 )
 			continue;
-		
+
 		// I'm not quite sure what it means to have two services with this device.
 		// Iterate over them all. If one contains what we want, stop.
 		io_registry_entry_t device; // This is the same as an io_object_t.
-		
+
 		while( (device = IOIteratorNext(iter)) )
 		{
 			// Look at the parent of the device until we see an IOUSBMassStorageClass
@@ -169,15 +170,15 @@ void MemoryCardDriverThreaded_MacOSX::GetUSBStorageDevices( vector<UsbStorageDev
 			}
 			if( device == MACH_PORT_NULL )
 				continue;
-			
+
 			// At this point, it is pretty safe to say that we've found a USB device.
 			vDevicesOut.push_back( UsbStorageDevice() );
 			UsbStorageDevice& usbd = vDevicesOut.back();
-			
+
 			LOG->Trace( "Found memory card at path: %s.", fs[i].f_mntonname );
 			usbd.SetOsMountDir( fs[i].f_mntonname );
 			usbd.iVolumeSizeMB = int( (uint64_t(fs[i].f_blocks) * fs[i].f_bsize) >> 20 );
-		
+
 			// Now we can get some more information from the registry tree.
 			usbd.iBus = GetIntProperty( device, CFSTR("USB Address") );
 			usbd.iPort = GetIntProperty( device, CFSTR("PortNum") );
@@ -210,7 +211,7 @@ bool MemoryCardDriverThreaded_MacOSX::TestWrite( UsbStorageDevice *pDevice )
 /*
  * (c) 2005-2006, 2008 Steve Checkoway
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -220,7 +221,7 @@ bool MemoryCardDriverThreaded_MacOSX::TestWrite( UsbStorageDevice *pDevice )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF


### PR DESCRIPTION
### macOS (Catalina+) – Fix build/link on modern SDKs and Apple Silicon

#### Summary
Modern Apple SDKs/Xcode were failing to compile/link StepMania 5.1 due to stricter headers, legacy Carbon symbols not being auto-linked, and libpng NEON link issues on arm64. This PR updates build glue and one include to make the project build and run on macOS 10.15+ (including Apple Silicon).

#### What changed
- **CoreFoundation include for CF APIs**
  - `src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp`
    - Added `#include <CoreFoundation/CoreFoundation.h>` so CFNumber/CFBoolean/CFType APIs resolve with modern SDKs.

- **Explicit macOS framework linking**
  - `StepmaniaCore.cmake`
    - Link `Carbon` explicitly (required for `GetMainEventLoop`, `GetCFRunLoopFromEventLoop`, TIS functions).
    - Make `HIToolbox` optional and only link when found (may not exist on all SDKs).
    - Updated framework discovery and linking order.

  - `src/CMakeLists.txt`
    - Added conditional linking for `HIToolbox` only when available.
    - Ensured `Carbon` is always linked for input handling.

- **Apple Silicon libpng fix**
  - `extern/CMakeProject-png.cmake`
    - Disable `PNG_ARM_NEON_OPT` on Apple platforms to avoid unresolved ARM NEON symbols on arm64.

#### Testing
- ✅ Configure succeeds with `cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_SYSTEM_FFMPEG=ON`
- ✅ Build completes without errors on macOS 14.6 (Apple Silicon)
- ✅ App launches and runs correctly
- ✅ Input detection works (requires Input Monitoring permission on modern macOS)

#### Build instructions (macOS)
```bash
# Prerequisites
brew install cmake nasm ffmpeg pkg-config
xcode-select --install

# Build
cmake -S . -B build -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_SYSTEM_FFMPEG=ON
cmake --build build --parallel

# Run
open ./StepMania.app
```

#### Notes
- Uses system FFmpeg to avoid bundled FFmpeg compilation issues
- Input Monitoring permission required on macOS 10.15+ for keyboard/joystick detection
- Compatible with Xcode 16 and modern macOS SDKs